### PR TITLE
Add tests that checks that a user cannot burn or transfer more than their current balance

### DIFF
--- a/test/DRIP20.t.sol
+++ b/test/DRIP20.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 import "ds-test/test.sol";
 import {console} from "forge-std/console.sol";
+import {stdError} from "forge-std/Test.sol";
 import {MockDRIP20} from "./mocks/MockDRIP20.sol";
 
 interface Vm {
@@ -283,6 +284,14 @@ contract DRIP20Test is DSTest {
 
         assertEq(token.totalSupply(), 50);
         assertEq(token.balanceOf(user1), 50);
+    }
+
+    function testRevertTransferMoreThanBalance() public {
+        vm.startPrank(user1);
+        token.mint(40);
+
+        vm.expectRevert(stdError.arithmeticError);
+        token.transfer(user2, 50);
     }
 
     function testRevertStartDrip() public {

--- a/test/DRIP20.t.sol
+++ b/test/DRIP20.t.sol
@@ -294,6 +294,14 @@ contract DRIP20Test is DSTest {
         token.transfer(user2, 50);
     }
 
+    function testRevertBurnMoreThanBalance() public {
+        vm.startPrank(user1);
+        token.mint(40);
+
+        vm.expectRevert(stdError.arithmeticError);
+        token.burn(user1, 50);
+    }
+
     function testRevertStartDrip() public {
         // need to start on a non zero block number since we use block 0 as 'not dripping'
         vm.roll(1);


### PR DESCRIPTION
Adds tests that checks that a user cannot burn or transfer more than their current balance.

I don't know how useful these tests are? I haven't written any solidity before but when you published the contracts for DRIP and Mirakai I wanted to see if I could review them and contribute. Since Solidity is syntactically very similar to js my brain was kind of in js-mode when I read the code and therefore thought that there was a bug in `transfer`, so I wrote a test to see if that was the case 😄 I quickly realized that I was ofc wrong but I figured that I might as well submit a PR with the tests! Do you think these are worth merging? If yes, would you prefer if I update the PR to use the `testFail`-prefix instead of expecting an arithmetic error? It doesn't feel like the reason why the code reverts is very important here, only that it does revert, but I followed the same pattern that you used for other tests that checks for reverts