### PR TITLE
Use custom errors

### DIFF
--- a/src/GIGADRIP20.sol
+++ b/src/GIGADRIP20.sol
@@ -8,8 +8,14 @@ pragma solidity ^0.8.0;
 ///@notice should accrue 3 times as many tokens per block. This user would have a multiplier of 3.
 ///@notice shout out to solmate (@t11s) for the slim and efficient ERC20 implementation!
 ///@notice shout out to superfluid and UBI for the dripping inspiration!
-
 abstract contract GIGADRIP20 {
+    /*==============================================================
+    ==                            ERRORS                          ==
+    ==============================================================*/
+
+    error UserNotAccruing();
+    error ERC20_TransferToZeroAddress();
+
     /*==============================================================
     ==                            EVENTS                          ==
     ==============================================================*/
@@ -138,7 +144,7 @@ abstract contract GIGADRIP20 {
         address to,
         uint256 amount
     ) internal virtual {
-        require(to != address(0), "ERC20: transfer to the zero address");
+        if (to == address(0)) revert ERC20_TransferToZeroAddress();
 
         Accruer storage fromAccruer = _accruers[from];
         Accruer storage toAccruer = _accruers[to];
@@ -203,7 +209,7 @@ abstract contract GIGADRIP20 {
         Accruer storage accruer = _accruers[addr];
 
         // should I check for 0 multiplier too
-        require(accruer.accrualStartBlock != 0, "user not accruing");
+        if (accruer.accrualStartBlock == 0) revert UserNotAccruing();
 
         accruer.balance = balanceOf(addr);
         _currAccrued = totalSupply();

--- a/test/DRIP20.t.sol
+++ b/test/DRIP20.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.0;
 import "ds-test/test.sol";
 import {console} from "forge-std/console.sol";
 import {MockDRIP20} from "./mocks/MockDRIP20.sol";
+import {DRIP20} from "../src/DRIP20.sol";
 
 interface Vm {
     function prank(address) external;
@@ -17,6 +18,7 @@ interface Vm {
     function roll(uint256) external;
 
     function expectRevert(bytes calldata) external;
+    function expectRevert(bytes4) external;
 
     function expectEmit(
         bool,
@@ -289,14 +291,14 @@ contract DRIP20Test is DSTest {
         // need to start on a non zero block number since we use block 0 as 'not dripping'
         vm.roll(1);
         token.startDripping(user1);
-        vm.expectRevert(bytes("user already accruing"));
+        vm.expectRevert(DRIP20.UserAlreadyAccruing.selector);
         token.startDripping(user1);
     }
 
     function testRevertStopDrip() public {
         // need to start on a non zero block number since we use block 0 as 'not dripping'
         vm.roll(1);
-        vm.expectRevert(bytes("user not accruing"));
+        vm.expectRevert(DRIP20.UserNotAccruing.selector);
         token.stopDripping(user1);
     }
 }


### PR DESCRIPTION
Using custom errors reduces the deployment cost a little bit.

Output from `forge test --gas-report` diffed against master:
```diff
 ╭─────────────────────┬─────────────────┬───────┬─────── ─┬───────┬─────────╮
 │ MockDRIP20 contract ┆                 ┆       ┆        ┆       ┆         │
 ╞═════════════════════╪═════════════════╪═══════╪════════╪═══════╪═════════╡
 │ Deployment Cost     ┆ Deployment Size ┆       ┆        ┆       ┆         │
 ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
-│ 596157              ┆ 3751            ┆       ┆        ┆       ┆         │
+│ 568332              ┆ 3612            ┆       ┆        ┆       ┆         │
 ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤

 ╭─────────────────────────┬─────────────────┬───────┬─── ─────┬───────┬─────────╮
 │ MockGIGADRIP20 contract ┆                 ┆       ┆        ┆       ┆         │
 ╞═════════════════════════╪═════════════════╪═══════╪════════╪═══════╪═════════╡
 │ Deployment Cost         ┆ Deployment Size ┆       ┆        ┆       ┆         │
 ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
-│ 586751                  ┆ 3704            ┆       ┆        ┆       ┆         │
+│ 566732                  ┆ 3604            ┆       ┆        ┆       ┆         │
 ├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌┤
```